### PR TITLE
Hide collection view cell upon selection

### DIFF
--- a/CustomTransitionTutorial/Classes/ViewControllers/Animator.swift
+++ b/CustomTransitionTutorial/Classes/ViewControllers/Animator.swift
@@ -84,6 +84,8 @@ final class Animator: NSObject, UIViewControllerAnimatedTransitioning {
         // 33
         if isPresenting {
             selectedCellImageViewSnapshot = cellImageSnapshot
+            
+            selectedCell.alpha = 0
 
             // 41
             backgroundView = UIView(frame: containerView.bounds)
@@ -92,6 +94,7 @@ final class Animator: NSObject, UIViewControllerAnimatedTransitioning {
         } else {
             backgroundView = firstViewController.view.snapshotView(afterScreenUpdates: true) ?? fadeView
             backgroundView.addSubview(fadeView)
+            selectedCell.alpha = 1
         }
 
         // 23


### PR DESCRIPTION
Proposing a small addition to this repo to make the cell's transition feel more like it is becoming a part of the image view on the detail view controller. Airbnb does this trick as well by making the cell disappear after it is selected. 

Here is a side-by-side demo from Airbnb and this project (after the changes):

<img src="https://media.giphy.com/media/cl2scBBeblAKEGwrsA/giphy.gif" height="380px"> <img src="https://media.giphy.com/media/YTQ7x0iV2ptUvFFnvZ/giphy.gif" height="380px">